### PR TITLE
Add plugin section in the karma configuration of the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ module.exports = function(config) {
     files: [
       '*.js',
       '*.html'
+    ],
+    
+    plugins: [
+      'karma-html2js-preprocessor'
     ]
   });
 };


### PR DESCRIPTION
In order to make the **README.md** easier to follow.
This pull request adds `karma-html2js-preprocessor` in the `plugin` section of the `karma.conf.js` file so that people don't forget to add it.
