### PR TITLE
Allow for failures

### DIFF
--- a/e2e-test/spec.js
+++ b/e2e-test/spec.js
@@ -1,6 +1,6 @@
 describe('template', function() {
   it('should expose the templates to __html__', function() {
     document.body.innerHTML = __html__['template.html'];
-    expect(document.getElementById('tpl')).toBeDefined();
+    expect(document.getElementById('tpl')).toBeTruthy();
   })
 })


### PR DESCRIPTION
If the template was not properly loaded `document.getElementById('tpl')` would return `null`. Then `expect(...).toBeDefined()` would still report a success. I changed it to `expect(...).toBeTruthy()` so it actually reports a failure if something goes wrong.
