### PR TITLE
Fixed bad path when file is processed multiple times

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -17,7 +17,7 @@ var createHtml2JsPreprocessor = function(logger, basePath) {
 
     var htmlPath = file.originalPath.replace(basePath + '/', '');
 
-    file.path = file.path + '.js';
+    file.path = file.originalPath + '.js';
     done(util.format(TEMPLATE, htmlPath, escapeContent(content)));
   };
 };

--- a/test/html2js.spec.coffee
+++ b/test/html2js.spec.coffee
@@ -27,6 +27,21 @@ describe 'preprocessors html2js', ->
       expect(file.path).to.equal '/base/path/file.html.js'
       done()
 
+  it 'should change path to *.js only once', (done) ->
+    # Test case for bug where processing the same file
+    # twice results in the path changing to *.js.js .
+    # Multiple processing can occur when you edit the underlying
+    # .html file multiple times while using karma to proxy the
+    # files for your dev environment.
+    file = new File '/base/path/file.html'
+
+    process '', file, (processedContent) ->
+      expect(file.path).to.equal '/base/path/file.html.js'
+
+    process '', file, (processedContent) ->
+      expect(file.path).to.equal '/base/path/file.html.js'
+      done()
+
 
   it 'should preserve new lines', (done) ->
     file = new File '/base/path/file.html'


### PR DESCRIPTION
Fixed bug that caused the path of the generated javascript file to
be appended multiple times with '.js', once for each time the
file was processed.  This resulted in the file's path going from
*.js to *.js.js to *.js.js.js, etc.

A file can be processed multiple times when you are using karma
in your development environment to proxy the resulting '.js' files
and you edit the underlying '_.html'.  Currently, you have to restart
karma everytime you edit an '_.html' file.
