### PR TITLE
Added stripPrefix, prependPrefix, and processPath

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ npm install karma-html2js-preprocessor --save-dev
 ```
 
 ## Configuration
-Following code shows the default configuration...
+
 ```js
 // karma.conf.js
 module.exports = function(config) {
@@ -34,7 +34,21 @@ module.exports = function(config) {
     files: [
       '*.js',
       '*.html'
-    ]
+    ],
+
+    html2JsPreprocessor: {
+      // strip this from the file path
+      stripPrefix: 'public/',
+
+      // prepend this to the file path
+      prependPrefix: 'served/',
+
+      // or define a custom transform function
+      processPath: function(filePath) {
+        // Drop the file extension
+        return filePath.replace(/\.html$/, '');
+      }
+    }
   });
 };
 ```

--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -9,19 +9,27 @@ var escapeContent = function(content) {
   return content.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
 };
 
-var createHtml2JsPreprocessor = function(logger, basePath) {
+var createHtml2JsPreprocessor = function(logger, basePath, config) {
+  config = typeof config === 'object' ? config : {};
+
   var log = logger.create('preprocessor.html2js');
+  var stripPrefix = config.stripPrefix ? new RegExp('^' + config.stripPrefix) : null;
+  var prependPrefix = config.prependPrefix ? config.prependPrefix : '';
+  var processPath = config.processPath || function(htmlPath) {
+    htmlPath = prependPrefix + htmlPath.replace(stripPrefix, '');
+    return htmlPath;
+  };
 
   return function(content, file, done) {
     log.debug('Processing "%s".', file.originalPath);
 
-    var htmlPath = file.originalPath.replace(basePath + '/', '');
+    var htmlPath = processPath(file.originalPath.replace(basePath + '/', ''));
 
     file.path = file.path + '.js';
     done(util.format(TEMPLATE, htmlPath, escapeContent(content)));
   };
 };
 
-createHtml2JsPreprocessor.$inject = ['logger', 'config.basePath'];
+createHtml2JsPreprocessor.$inject = ['logger', 'config.basePath', 'config.html2JsPreprocessor'];
 
 module.exports = createHtml2JsPreprocessor;


### PR DESCRIPTION
This PR includes options that give `karma-html2js-preprocessor` feature parity with `karma-ng-html2js-preprocessor` for non-Angular use cases.

The following options have been added:
- `stripPrefix` - Remove this prefix from the file path
- `prependPrefix` - Prepend this prefix to the file path
- `processPath` - Custom function that accepts the `filePath` and transforms it as necessary

`processPath` is equivalent to  `karma-ng-html2js-preprocessor`'s `cacheIdFromPath` option. I'm not sure on the naming here, I'll gladly change it if there is a better name that follows Karma's naming conventions better.
