### PR TITLE
Fixes escaping of backslashes

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -6,7 +6,7 @@ var TEMPLATE = '' +
   'window.__html__[\'%s\'] = \'%s\'';
 
 var escapeContent = function(content) {
-  return content.replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
+  return content.replace(/\\/g, '\\\\').replace(/'/g, '\\\'').replace(/\r?\n/g, '\\n\' +\n    \'');
 };
 
 var createHtml2JsPreprocessor = function(logger, basePath) {


### PR DESCRIPTION
Escapes backslashes.

This pull request is similar to #15 but differs in that it escapes backslashes in all file types. See [my comment in #15](https://github.com/karma-runner/karma-html2js-preprocessor/pull/15#issuecomment-88616017) for an example why I think backslashes have to be escaped in all file types.