### PR TITLE
apply processPath function to file.path to

### DIFF
--- a/lib/html2js.js
+++ b/lib/html2js.js
@@ -25,7 +25,7 @@ var createHtml2JsPreprocessor = function(logger, basePath, config) {
 
     var htmlPath = processPath(file.originalPath.replace(basePath + '/', ''));
 
-    file.path = file.path + '.js';
+    file.path = processPath(file.path) + '.js';
     done(util.format(TEMPLATE, htmlPath, escapeContent(content)));
   };
 };


### PR DESCRIPTION
If karma works in watch mode, when the .html files are updated, the preprocessor creates the names of the '*.js.js', '*.js.js.js' etc. files.
This change in order to be able to fix it with settings like
    html2JsPreprocessor: {
      processPath: function(filePath) {
        return filePath.replace(/\.js$/, '');
      }
    },